### PR TITLE
Build robot docker image from almalinux:9

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -9,10 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v4
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -22,7 +19,7 @@ jobs:
 
       - name: Docker meta for testsuite
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: indigoiam/robot-framework
           flavor: latest=true
@@ -32,7 +29,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./docker
           file: ./docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ The image, besides a recent, python3 based Robot framework environment, provides
 - oidc-agent
 - voms clients
 - gfal
-- curl (compiled against OpenSSL)
+- davix
+- jwt
 
 More details in the [Dockerfile](./docker/Dockerfile).
 
 The image is currently used by:
 
 - The [WLCG JWT compliance test suite][wlcg-jwt-compliance-tests]
-- The [ESCAPE authN/Z test suite][escape-auth-tests]
+- The [StoRM Tape test suite][storm-tape-ts]
+- The [StoRM WebDAV test suite][storm-webdav]
 
 The image is built in CI on every commit or pull request submitted to this repo. It is pushed on [DockerHub][dockerhub-repo] when the code is tagged.
 
@@ -23,5 +25,6 @@ The Docker image name is `indigoiam/robot-framework`. To see the list of tags av
 
 [robot]: https://robotframework.org/
 [wlcg-jwt-compliance-tests]: https://github.com/indigo-iam/wlcg-jwt-compliance-tests
-[escape-auth-tests]: https://github.com/indigo-iam/escape-auth-tests
+[storm-tape-ts]: https://baltig.infn.it/cnafsd/storm-tape-ts
+[storm-webdav]: https://github.com/italiangrid/storm-webdav/tree/develop/robot
 [dockerhub-repo]: https://hub.docker.com/r/indigoiam/robot-framework

--- a/docker/.env
+++ b/docker/.env
@@ -1,2 +1,2 @@
-DOCKER_IMAGE=indigoiam/robot-framework-docker
 DOCKER_VERBOSE=y
+DOCKER_OPTS=--rm=true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,57 +1,25 @@
-FROM centos:7
+FROM almalinux:9
 
-ARG TEST_USER=test
-ARG TEST_USER_UID=1000
+ARG USERNAME=test
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
 
-ENV TEST_USER $TEST_USER
-ENV TEST_USER_UID $TEST_USER_UID
+COPY /scripts/*.sh /tmp/scripts/
 
-RUN   yum clean all && \
-      yum install -y hostname epel-release attr which && \
-      yum -y update && \
-      yum -y install git which wget tar gcc openssl-devel sudo file make python36 && \
-      echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-      adduser --uid ${TEST_USER_UID} ${TEST_USER} && \
-      usermod -a -G wheel ${TEST_USER} && \
-      mkdir /home/test/.config && chown test:test /home/test/.config && \
-      yum -y install telnet nc
+RUN   dnf install -y epel-release && \
+      curl -L https://repo.data.kit.edu//data-kit-edu-almalinux9.repo -o /etc/yum.repos.d/data-kit-edu-almalinux9.repo && \
+      dnf -y update && \
+      dnf -y install git which sudo jq \
+        voms-clients-cpp voms-clients-java python3-gfal2-util gfal2-all python3-gfal2 davix oidc-agent \
+        python3-pip python3-devel python3-setuptools && \
+      dnf module install -y nodejs:18 && \
+      npm install -g jwt-cli && \
+      rm -rf /var/cache/dnf && \
+      bash /tmp/scripts/provide-user.sh ${USERNAME} ${USER_UID} ${USER_GID} && \
+      mkdir /home/${USERNAME}/.config /home/${USERNAME}/.globus && \
+      chown -R ${USERNAME}:${USERNAME} /home/${USERNAME} && \
+      bash /tmp/scripts/provide-robotframework.sh && \
+      rm -rf /tmp/scripts
 
-RUN cd /root && \
-    wget https://curl.haxx.se/download/curl-7.72.0.tar.gz && \
-    tar xvzf curl-7.72.0.tar.gz && \
-    cd curl-7.72.0 && \
-    ./configure --with-ssl --disable-dependency-tracking && \
-    make && make install && \
-    cd .. && rm -rf curl-7.72.0 && rm curl-7.72.0.tar.gz
-
-RUN wget https://ci.cloud.cnaf.infn.it/view/repos/job/repo_test_ca/lastSuccessfulBuild/artifact/test-ca.repo -O /etc/yum.repos.d/test-ca.repo && \
-    yum -y clean all && yum -y install igi-test-ca && \
-    mkdir -p /home/test/.globus && cp /usr/share/igi-test-ca/test0.p12 /home/test/.globus/usercred.p12 && \
-    chmod 600 /home/test/.globus/usercred.p12 && \
-    chown -R test:test /home/test/.globus
-
-RUN yum -y install voms-clients-java gfal2-util gfal2-all gfal2-python davix jq && \
-    curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
-    yum install -y nodejs && \
-    npm install -g jwt-cli && \
-    yum clean all && \
-    wget https://repo.data.kit.edu/data-kit-edu-centos7.repo -O /etc/yum.repos.d/data-kit-edu-centos7.repo && \
-    yum install -y oidc-agent && \
-    pip3 install --upgrade pip && \
-    pip3 install --upgrade robotframework-httplibrary && \
-    pip3 install --upgrade robotframework-jsonlibrary && \
-    pip3 install --upgrade oic && \
-    pip3 install --upgrade requests && \
-    pip3 install --upgrade pyyaml && \
-    pip3 install --upgrade shyaml && \
-    # bug in newer pyjwt version reported in https://github.com/Azure/azure-sdk-for-python/issues/16035
-    pip3 install pyjwt==1.7.0 && \
-    rm -rf /var/cache/yum
-
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
-
-USER test
-WORKDIR /home/test
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}

--- a/docker/scripts/provide-robotframework.sh
+++ b/docker/scripts/provide-robotframework.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+python3 -m pip install --upgrade pip && \
+python3 -m pip install --upgrade robotframework && \
+python3 -m pip install --upgrade robotframework-httplibrary && \
+python3 -m pip install --upgrade robotframework-jsonlibrary && \
+python3 -m pip install --upgrade oic && \
+python3 -m pip install --upgrade requests && \
+python3 -m pip install --upgrade pyyaml && \
+python3 -m pip install --upgrade pyjwt

--- a/docker/scripts/provide-user.sh
+++ b/docker/scripts/provide-user.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+USERNAME=${1}
+USER_UID=${2}
+USER_GID=${3}
+
+set -ex
+
+groupadd --gid $USER_GID $USERNAME
+useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+chmod 0440 /etc/sudoers.d/$USERNAME


### PR DESCRIPTION
The test certificates are removed in this image such to let them be uploaded when needed by the test suites.
This update should also solve issue #1.